### PR TITLE
Fix phone not loading

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -87,11 +87,14 @@ QBCore.Functions.CreateCallback('qb-phone:server:GetPhoneData', function(source,
         local garageresult = exports.ghmattimysql:executeSync('SELECT * FROM player_vehicles WHERE citizenid=@citizenid', {['@citizenid'] = Player.PlayerData.citizenid})
         if garageresult[1] ~= nil then
             for k, v in pairs(garageresult) do
-                if (QBCore.Shared.Vehicles[v.vehicle] ~= nil) and (Garages[v.garage] ~= nil) then
+			
+		local vehicleModel = v.vehicle	
+                if (QBCore.Shared.Vehicles[vehicleModel] ~= nil) and (Garages[v.garage] ~= nil) then
                     v.garage = Garages[v.garage].label
-                    v.vehicle = QBCore.Shared.Vehicles[v.vehicle].name
-                    v.brand = QBCore.Shared.Vehicles[v.vehicle].brand
+                    v.vehicle = QBCore.Shared.Vehicles[vehicleModel].name
+                    v.brand = QBCore.Shared.Vehicles[vehicleModel].brand
                 end
+				
             end
             PhoneData.Garage = garageresult
         end


### PR DESCRIPTION
There is a problem with retrieving garage data on the phone which causes the phone not to return data when requested via the callback.

At runtime `v.vehicle` is the vehicle model (eg `bati`) however on L92 `v.vehicle` is reassigned to the vehicle display name (eg `Bati 801`) however `v.vehicle` is then used on L93 as an index in the vehicle table to get the brand details.

This will store the model and then use that so the re-assignment doesn't affect the following line.