### PR TITLE
fix: Opening phone while dead

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -2,9 +2,10 @@ local PlayerJob = {}
 local isLoggedIn = false
 
 RegisterCommand('phone', function()
+    PlayerData = QBCore.Functions.GetPlayerData()
     if not PhoneData.isOpen and isLoggedIn then
         local IsHandcuffed = exports['qb-policejob']:IsHandcuffed()
-        if not IsHandcuffed then
+        if not IsHandcuffed and not PlayerData.metadata['inlaststand'] and not PlayerData.metadata['isdead'] then
             OpenPhone()
         else
             QBCore.Functions.Notify("Action not available at the moment..", "error")


### PR DESCRIPTION
Stops the player from opening the phone while dead, or in last stand.