### PR TITLE
Fix SQL 'read' error

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -217,11 +217,11 @@ AddEventHandler('qb-phone:server:sendNewMail', function(mailData)
 
     if mailData.button == nil then
         exports.oxmysql:insert(
-            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read) VALUES (?, ?, ?, ?, ?, ?)',
+            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`) VALUES (?, ?, ?, ?, ?, ?)',
             {Player.PlayerData.citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0})
     else
         exports.oxmysql:insert(
-            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
             {Player.PlayerData.citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0,
              json.encode(mailData.button)})
     end
@@ -250,12 +250,12 @@ AddEventHandler('qb-phone:server:sendNewMailToOffline', function(citizenid, mail
 
         if mailData.button == nil then
             exports.oxmysql:insert(
-                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read) VALUES (?, ?, ?, ?, ?, ?)',
+                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`) VALUES (?, ?, ?, ?, ?, ?)',
                 {Player.PlayerData.citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0})
             TriggerClientEvent('qb-phone:client:NewMailNotify', src, mailData)
         else
             exports.oxmysql:insert(
-                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
+                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
                 {Player.PlayerData.citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0,
                  json.encode(mailData.button)})
             TriggerClientEvent('qb-phone:client:NewMailNotify', src, mailData)
@@ -277,11 +277,11 @@ AddEventHandler('qb-phone:server:sendNewMailToOffline', function(citizenid, mail
     else
         if mailData.button == nil then
             exports.oxmysql:insert(
-                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read) VALUES (?, ?, ?, ?, ?, ?)',
+                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`) VALUES (?, ?, ?, ?, ?, ?)',
                 {Player.PlayerData.citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0})
         else
             exports.oxmysql:insert(
-                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
+                'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
                 {Player.PlayerData.citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0,
                  json.encode(mailData.button)})
         end
@@ -293,11 +293,11 @@ AddEventHandler('qb-phone:server:sendNewEventMail', function(citizenid, mailData
     local Player = QBCore.Functions.GetPlayerByCitizenId(citizenid)
     if mailData.button == nil then
         exports.oxmysql:insert(
-            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read) VALUES (?, ?, ?, ?, ?, ?)',
+            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`) VALUES (?, ?, ?, ?, ?, ?)',
             {citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0})
     else
         exports.oxmysql:insert(
-            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, read, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO player_mails (citizenid, sender, subject, message, mailid, `read`, button) VALUES (?, ?, ?, ?, ?, ?, ?)',
             {citizenid, mailData.sender, mailData.subject, mailData.message, GenerateMailId(), 0,
              json.encode(mailData.button)})
     end


### PR DESCRIPTION
This commit will fix the error that databases have while trying to parse 'read' due to the fact 'read' is a function and causes a syntax error.