### PR TITLE
Updated main.lua

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1667,6 +1667,7 @@ end)
 RegisterNetEvent('qb-phone:client:RemoveBankMoney')
 AddEventHandler('qb-phone:client:RemoveBankMoney', function(amount)
     --if PhoneData.isOpen then
+      if amount > 0 then 
         SendNUIMessage({
             action = "PhoneNotification",
             PhoneNotify = {
@@ -1677,6 +1678,7 @@ AddEventHandler('qb-phone:client:RemoveBankMoney', function(amount)
                 timeout = 3500,
             },
         })
+    end
 end)
 
 RegisterNetEvent('qb-phone:client:AddTransaction')


### PR DESCRIPTION
A fix for the "0$ has been removed from your bank account". A simple if statement on line 1670 checks if the amount removed from your bank account is greater than 0. If it is, it sends the notification with the correct amount, if not, the item is free and the phone notification does not go through, since it's practically useless.