### PR TITLE
fix: gang/job garages show as none in phone

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -591,6 +591,10 @@ QBCore.Functions.CreateCallback('qb-phone:server:GetGarageVehicles', function(so
             if v.garage ~= nil then
                 if Garages[v.garage] ~= nil then
                     VehicleGarage = Garages[v.garage]["label"]
+                elseif GangGarages[v.garage] ~= nil then
+                    VehicleGarage = GangGarages[v.garage]["label"]
+                elseif JobGarages[v.garage] ~= nil then
+                    VehicleGarage = JobGarages[v.garage]["label"]
                 end
             end
 


### PR DESCRIPTION
When using a gang or job garage the phone app was returning none as the label and in as the status when the vehicle was stored in a garage.  This defines the GangGarages and JobGarages from the qb-garage config file.