### PR TITLE
Prevent 2 exploits

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1151,6 +1151,7 @@ RegisterNUICallback('CanTransferMoney', function(data, cb)
             if Transferd then
                 cb({TransferedMoney = true, NewBalance = (PlayerData.money.bank - amount)})
             else
+		SendNUIMessage({ action = "PhoneNotification", PhoneNotify = { timeout=3000, title = "Bank", text = "Account does not exist!", icon = "fas fa-university", color = "#ff0000", }, })
                 cb({TransferedMoney = false})
             end
         end, amount, iban)

--- a/server/main.lua
+++ b/server/main.lua
@@ -8,6 +8,7 @@ local Calls = {}
 local Adverts = {}
 local GeneratedPlates = {}
 local WebHook = ""
+local bannedCharacters = {'%','$',';'}
 
 -- Functions
 
@@ -653,9 +654,19 @@ QBCore.Functions.CreateCallback('qb-phone:server:HasPhone', function(source, cb)
 end)
 
 QBCore.Functions.CreateCallback('qb-phone:server:CanTransferMoney', function(source, cb, amount, iban)
+    -- strip bad characters from bank transfers
+    local newAmount = tostring(amount)
+    local newiban = tostring(iban)
+    for k, v in pairs(bannedCharacters) do
+        newAmount = string.gsub(newAmount, '%' .. v, '')
+        newiban = string.gsub(newiban, '%' .. v, '')
+    end
+    iban = newiban
+    amount = tonumber(newAmount)
+    
     local Player = QBCore.Functions.GetPlayer(source)
     if (Player.PlayerData.money.bank - amount) >= 0 then
-        local query = '%' .. iban .. '%'
+        local query = '%"account":"' .. iban .. '"%'
         local result = exports.oxmysql:executeSync('SELECT * FROM players WHERE charinfo LIKE ?', {query})
         if result[1] ~= nil then
             local Reciever = QBCore.Functions.GetPlayerByCitizenId(result[1].citizenid)
@@ -669,7 +680,6 @@ QBCore.Functions.CreateCallback('qb-phone:server:CanTransferMoney', function(sou
             end
             cb(true)
         else
-            TriggerClientEvent('QBCore:Notify', source, "This account number does not exist!", "error")
             cb(false)
         end
     end


### PR DESCRIPTION
Exploit 1: User can do exploit with `%` in place of the actual account, and it would process the money, put it the first account it finds in the database. 
Exploit 2: User can type `1` or `Core034`, a partial account transfer, and then those funds will process to the first match. This converts that search to a "must 100%" match technique.

I have tested these changes on my server and it patches the bank app. Incoming PR for crypto.