### PR TITLE
(Minor/Perf) Reduce amount of Tweets loaded on phone

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,7 @@ Config.BillingCommissions = { -- This is a percentage (0.10) == 10%
     mechanic = 0.10
 }
 Config.Linux = false -- True if linux
+Config.TweetDuration = 12 -- How many hours to load tweets (12 will load the past 12 hours of tweets)
 Config.RepeatTimeout = 2000
 Config.CallRepeats = 10
 Config.OpenPhone = 244

--- a/server/main.lua
+++ b/server/main.lua
@@ -311,7 +311,7 @@ QBCore.Functions.CreateCallback('qb-phone:server:GetPhoneData', function(source,
             PhoneData.Hashtags = Hashtags
         end
 
-        local Tweets = exports.oxmysql:executeSync('SELECT * FROM phone_tweets', {})
+        local Tweets = exports.oxmysql:executeSync('SELECT * FROM phone_tweets WHERE `date` > NOW() - INTERVAL ? hour', {Config.TweetDuration})
         
         if Tweets ~= nil and next(Tweets) ~= nil then
             PhoneData.Tweets = Tweets


### PR DESCRIPTION
This will create a new variable in the config to prevent the phone from loading weeks of tweets. It is set by hours and I have been using this in my server for a few days once the phone started becoming slow from the amount of tweets. This is an alternative that eliminates the need to setup a cron job to delete the tweets (which should still be done, but at least this prevents the end user from being punished for it). The time filter is handled in MySQL to prevent any extra computation on the server.

Tested: Yes - on Linux
Standards: Sure