### PR TITLE
Fix camera looping when no webhook

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1370,6 +1370,10 @@ RegisterNUICallback("TakePhoto", function(data,cb)
                         cb(json.encode(image.attachments[1].proxy_url))
                     end)
                 else
+		    DestroyMobilePhone()
+                    CellCamActivate(false, false)
+                    cb(json.encode({ url = nil }))
+                    takePhoto = false
                     return
                 end
             end)


### PR DESCRIPTION
Camera app would stick player in an infinite loop if they took a photo when there was no webhook. Now, when there is no webhook and a photo is taken the camera app simply closes.