### PR TITLE
Adding Emergency Service control center

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -481,6 +481,10 @@ QB.Phone.Functions.UpdateTime = function(data) {
     $("#phone-time").html("<span>" + data.InGameTime.hour + ":" + data.InGameTime.minute + "</span>");
 }
 
+QB.Phone.Functions.IsEmergencyNumber = function(phoneNumber) {
+    return phoneNumber === "911" || phoneNumber === "912"
+}
+
 var NotificationTimeout = null;
 
 QB.Screen.Notification = function(title, content, icon, timeout, color) {

--- a/html/js/lawyers.js
+++ b/html/js/lawyers.js
@@ -154,7 +154,7 @@ $(document).on('click', '.lawyer-list-call', function(e){
         ContactData: cData,
         Anonymous: QB.Phone.Data.AnonymousCall,
     }), function(status){
-        if (cData.number !== QB.Phone.Data.PlayerData.charinfo.phone) {
+        if (status.targetNumber !== QB.Phone.Data.PlayerData.charinfo.phone) {
             if (status.IsOnline) {
                 if (status.CanCall) {
                     if (!status.InCall) {
@@ -181,10 +181,18 @@ $(document).on('click', '.lawyer-list-call', function(e){
                         QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You are already connected to a call!");
                     }
                 } else {
-                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is already in a call");
+                    if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                    } else {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is busy!");
+                    }
                 }
             } else {
-                QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                } else {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                }
             }
         } else {
             QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You can't call your own number!");

--- a/html/js/phone.js
+++ b/html/js/phone.js
@@ -96,7 +96,7 @@ $(document).on('click', '.phone-recent-call', function(e){
         ContactData: cData,
         Anonymous: QB.Phone.Data.AnonymousCall,
     }), function(status){
-        if (cData.number !== QB.Phone.Data.PlayerData.charinfo.phone) {
+        if (status.targetNumber !== QB.Phone.Data.PlayerData.charinfo.phone) {
             if (status.IsOnline) {
                 if (status.CanCall) {
                     if (!status.InCall) {
@@ -123,10 +123,18 @@ $(document).on('click', '.phone-recent-call', function(e){
                         QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You're already in a call!");
                     }
                 } else {
-                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is busy!");
+                    if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                    } else {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is busy!");
+                    }
                 }
             } else {
-                QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                } else {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                }
             }
         } else {
             QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You can't call yourself!");
@@ -148,7 +156,7 @@ $(document).on('click', ".phone-keypad-key-call", function(e){
         ContactData: cData,
         Anonymous: QB.Phone.Data.AnonymousCall,
     }), function(status){
-        if (cData.number !== QB.Phone.Data.PlayerData.charinfo.phone) {
+        if (status.targetNumber !== QB.Phone.Data.PlayerData.charinfo.phone) {
             if (status.IsOnline) {
                 if (status.CanCall) {
                     if (!status.InCall) {
@@ -172,10 +180,18 @@ $(document).on('click', ".phone-keypad-key-call", function(e){
                         QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You're already in a call!");
                     }
                 } else {
-                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is busy!");
+                    if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                    } else {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is busy!");
+                    }
                 }
             } else {
-                QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                } else {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                }
             }
         } else {
             QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You can't call yourself!");
@@ -489,7 +505,7 @@ SetupCall = function(cData) {
         ContactData: cData,
         Anonymous: QB.Phone.Data.AnonymousCall,
     }), function(status){
-        if (cData.number !== QB.Phone.Data.PlayerData.charinfo.phone) {
+        if (status.targetNumber !== QB.Phone.Data.PlayerData.charinfo.phone) {
             if (status.IsOnline) {
                 if (status.CanCall) {
                     if (!status.InCall) {
@@ -513,10 +529,18 @@ SetupCall = function(cData) {
                         QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You're already in a call!");
                     }
                 } else {
-                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is in a call!");
+                    if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                    } else {
+                        QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is busy!");
+                    }
                 }
             } else {
-                QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                if (QB.Phone.Functions.IsEmergencyNumber(cData.number)) {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "ES currently not available. Try later!");
+                } else {
+                    QB.Phone.Notifications.Add("fas fa-phone", "Phone", "This person is not available!");
+                }
             }
         } else {
             QB.Phone.Notifications.Add("fas fa-phone", "Phone", "You can't call your own number!");


### PR DESCRIPTION
This addition gives players of `police` or `ambulance` job the ability to enter the control center.

The control center serves the purpose that civilians can call `911` or `912` for emergency services and will be forwarded to the person who is currently operating the control center.

Control center operators will see the caller's phone number but callers won't see the operators personal phone number. Instead they will see the Emergency Service number in their recent calls.

PS: @ItsANoBrainer please leave me one of those crispy gif reviews here 🤩