### PR TITLE
(fix) Phone tweet bug

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -739,39 +739,51 @@ RegisterNUICallback('PostNewTweet', function(data, cb)
     local TwitterMessage = data.Message
     local MentionTag = TwitterMessage:split("@")
     local Hashtag = TwitterMessage:split("#")
-
-    for i = 2, #Hashtag, 1 do
-        local Handle = Hashtag[i]:split(" ")[1]
-        if Handle ~= nil or Handle ~= "" then
-            local InvalidSymbol = string.match(Handle, patt)
-            if InvalidSymbol then
-                Handle = Handle:gsub("%"..InvalidSymbol, "")
+    if #Hashtag <= 3 then
+        for i = 2, #Hashtag, 1 do
+            local Handle = Hashtag[i]:split(" ")[1]
+            if Handle ~= nil or Handle ~= "" then
+                local InvalidSymbol = string.match(Handle, patt)
+                if InvalidSymbol then
+                    Handle = Handle:gsub("%"..InvalidSymbol, "")
+                end
+                TriggerServerEvent('qb-phone:server:UpdateHashtags', Handle, TweetMessage)
             end
-            TriggerServerEvent('qb-phone:server:UpdateHashtags', Handle, TweetMessage)
         end
-    end
 
-    for i = 2, #MentionTag, 1 do
-        local Handle = MentionTag[i]:split(" ")[1]
-        if Handle ~= nil or Handle ~= "" then
-            local Fullname = Handle:split("_")
-            local Firstname = Fullname[1]
-            table.remove(Fullname, 1)
-            local Lastname = table.concat(Fullname, " ")
+        for i = 2, #MentionTag, 1 do
+            local Handle = MentionTag[i]:split(" ")[1]
+            if Handle ~= nil or Handle ~= "" then
+                local Fullname = Handle:split("_")
+                local Firstname = Fullname[1]
+                table.remove(Fullname, 1)
+                local Lastname = table.concat(Fullname, " ")
 
-            if (Firstname ~= nil and Firstname ~= "") and (Lastname ~= nil and Lastname ~= "") then
-                if Firstname ~= PhoneData.PlayerData.charinfo.firstname and Lastname ~= PhoneData.PlayerData.charinfo.lastname then
-                    TriggerServerEvent('qb-phone:server:MentionedPlayer', Firstname, Lastname, TweetMessage)
+                if (Firstname ~= nil and Firstname ~= "") and (Lastname ~= nil and Lastname ~= "") then
+                    if Firstname ~= PhoneData.PlayerData.charinfo.firstname and Lastname ~= PhoneData.PlayerData.charinfo.lastname then
+                        TriggerServerEvent('qb-phone:server:MentionedPlayer', Firstname, Lastname, TweetMessage)
+                    end
                 end
             end
         end
+
+        PhoneData.Tweets[#PhoneData.Tweets+1] = TweetMessage
+        Wait(100)
+        cb(PhoneData.Tweets)
+
+        TriggerServerEvent('qb-phone:server:UpdateTweets', PhoneData.Tweets, TweetMessage)
+    else
+        SendNUIMessage({
+            action = "PhoneNotification",
+            PhoneNotify = {
+                title = "Twitter",
+                text = "Invalid Tweet",
+                icon = "fab fa-twitter",
+                color = "#1DA1F2",
+                timeout = 1000,
+            },
+        })
     end
-
-    PhoneData.Tweets[#PhoneData.Tweets+1] = TweetMessage
-    Wait(100)
-    cb(PhoneData.Tweets)
-
-    TriggerServerEvent('qb-phone:server:UpdateTweets', PhoneData.Tweets, TweetMessage)
 end)
 
 RegisterNUICallback('DeleteTweet',function(data, cb)


### PR DESCRIPTION
**Describe Pull request**
This fixes a breaking bug that if you post a tweet that has about 7 or more hashtags in it it will break the phone rendering it unable to be used and that tweet saves in the database so the only fix is to remove the offending tweet in the database this makes sure that can't happen in the first place.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
