### PR TITLE
fix(client): PhoneData.contacts to number type

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -54,7 +54,7 @@ end
 local function IsNumberInContacts(num)
     local retval = num
     for _, v in pairs(PhoneData.Contacts) do
-        if num == v.number then
+        if num == tonumber(v.number) then
             retval = v.name
         end
     end


### PR DESCRIPTION
This should fix players not showing up online on the phone, unable to call them or some other bugs that appeared with the phone number tonumber() changes in qb-core. Tried this with another player in a server, his name shows up green when online, he can be called again and his name is left behind in the recent caller list.

Looking at it, phone_contacts saves numbers as a varchar and turns it into a string.

This may be a fix but I believe the better fix would be to just 
1. Change the GetPlayerByPhone function in qb-core and add a tostring() over there
2. Revert the phone number generator

Instead of changing a bunch of stuff like this for example. There will probably be more bugs related to that change but this is one I could find and fix.
Would love more tests by others or input.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
I tried all the functionalities that I could think of, I might have missed some though.
- Does your code fit the style guidelines? [yes/no]
Should be since it's a simple tonumber()
- Does your PR fit the contribution guidelines? [yes/no]
Where can I find these?