### PR TITLE
Bring code to be in line with qb-garages config.lua 

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -196,8 +196,8 @@ QBCore.Functions.CreateCallback('qb-phone:server:GetPhoneData', function(source,
         if garageresult[1] ~= nil then
             for _, v in pairs(garageresult) do
                 local vehicleModel = v.vehicle
-                if (QBCore.Shared.Vehicles[vehicleModel] ~= nil) and (Garages[v.garage] ~= nil) then
-                    v.garage = Garages[v.garage].label
+                if (QBCore.Shared.Vehicles[vehicleModel] ~= nil) and (Config.Garages[v.garage] ~= nil) then
+                    v.garage = Config.Garages[v.garage].label
                     v.vehicle = QBCore.Shared.Vehicles[vehicleModel].name
                     v.brand = QBCore.Shared.Vehicles[vehicleModel].brand
                 end


### PR DESCRIPTION
Fix to coincide with the qb-garages changes in reference to https://github.com/qbcore-framework/qb-garages/pull/259

## Description

I was working on qb-garages and made the config.lua file match the rest of qb-core and in doing so I had to make modifications to qb-phone.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X ] My code fits the style guidelines.
- [X ] My PR fits the contribution guidelines.
