### PR TITLE
Allow movement while phone is in hand.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -272,6 +272,7 @@ local function OpenPhone()
     QBCore.Functions.TriggerCallback('qb-phone:server:HasPhone', function(HasPhone)
         if HasPhone then
             PhoneData.PlayerData = QBCore.Functions.GetPlayerData()
+            SetNuiFocusKeepInput(true)
             SetNuiFocus(true, true)
             SendNUIMessage({
                 action = "open",
@@ -545,6 +546,7 @@ RegisterNUICallback('Close', function(_, cb)
         PhoneData.AnimationData.anim = nil
         DoPhoneAnimation('cellphone_text_to_call')
     end
+    SetNuiFocusKeepInput(false)
     SetNuiFocus(false, false)
     SetTimeout(500, function()
         PhoneData.isOpen = false
@@ -1381,6 +1383,7 @@ RegisterNUICallback('SendMessage', function(data, cb)
 end)
 
 RegisterNUICallback("TakePhoto", function(_,cb)
+    SetNuiFocusKeepInput(false)
     SetNuiFocus(false, false)
     CreateMobilePhone(1)
     CellCamActivate(true, true)


### PR DESCRIPTION
-Added SetNuiFocusKeepInput() where appropriate to allow movement inputs while holding phone.

Closes #343  #320 
