### PR TITLE
Allow Movement While Phone in Hand - NUI Focus only when input required

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -797,6 +797,19 @@ RegisterNUICallback('GetMentionedTweets', function(_, cb)
     cb(PhoneData.MentionedTweets)
 end)
 
+RegisterNUICallback('SetFocusInput', function(_, cb)
+    SetNuiFocusKeepInput(false)
+    SetNuiFocus(true, true)
+    cb("ok")
+end)
+
+RegisterNUICallback('ReleaseFocusInput', function(_, cb)
+    SetNuiFocusKeepInput(true)
+    SetNuiFocus(true, true)
+    cb("ok")
+end)
+
+
 RegisterNUICallback('GetHashtags', function(_, cb)
     if PhoneData.Hashtags ~= nil and next(PhoneData.Hashtags) ~= nil then
         cb(PhoneData.Hashtags)

--- a/client/main.lua
+++ b/client/main.lua
@@ -272,6 +272,7 @@ local function OpenPhone()
     QBCore.Functions.TriggerCallback('qb-phone:server:HasPhone', function(HasPhone)
         if HasPhone then
             PhoneData.PlayerData = QBCore.Functions.GetPlayerData()
+            SetNuiFocusKeepInput(true)
             SetNuiFocus(true, true)
             SendNUIMessage({
                 action = "open",
@@ -545,6 +546,7 @@ RegisterNUICallback('Close', function(_, cb)
         PhoneData.AnimationData.anim = nil
         DoPhoneAnimation('cellphone_text_to_call')
     end
+    SetNuiFocusKeepInput(false)
     SetNuiFocus(false, false)
     SetTimeout(500, function()
         PhoneData.isOpen = false
@@ -1381,6 +1383,7 @@ RegisterNUICallback('SendMessage', function(data, cb)
 end)
 
 RegisterNUICallback("TakePhoto", function(_,cb)
+    SetNuiFocusKeepInput(false)
     SetNuiFocus(false, false)
     CreateMobilePhone(1)
     CellCamActivate(true, true)

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -256,6 +256,7 @@ $(document).on('click', '.phone-home-container', function(event){
     if (QB.Phone.Data.currentApplication === null) {
         QB.Phone.Functions.Close();
     } else {
+        $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
         QB.Phone.Animations.TopSlideUp('.phone-application-container', 400, -160);
         QB.Phone.Animations.TopSlideUp('.'+QB.Phone.Data.currentApplication+"-app", 400, -160);
         CanOpenApp = false;

--- a/html/js/bank.js
+++ b/html/js/bank.js
@@ -48,6 +48,7 @@ $(document).on('click', '.bank-app-header-button', function(e){
 
 QB.Phone.Functions.DoBankOpen = function() {
     QB.Phone.Data.PlayerData.money.bank = (QB.Phone.Data.PlayerData.money.bank).toFixed();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $(".bank-app-account-number").val(QB.Phone.Data.PlayerData.charinfo.account);
     $(".bank-app-account-balance").html("&#36; "+QB.Phone.Data.PlayerData.money.bank);
     $(".bank-app-account-balance").data('balance', QB.Phone.Data.PlayerData.money.bank);
@@ -85,11 +86,12 @@ QB.Phone.Functions.DoBankOpen = function() {
 
 $(document).on('click', '.bank-app-account-actions', function(e){
     QB.Phone.Animations.TopSlideDown(".bank-app-transfer", 400, 0);
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
 });
 
 $(document).on('click', '#cancel-transfer', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     QB.Phone.Animations.TopSlideUp(".bank-app-transfer", 400, -100);
 });
 
@@ -112,13 +114,16 @@ $(document).on('click', '#accept-transfer', function(e){
                     $(".bank-app-account-balance").html("&#36; " + (data.NewBalance).toFixed(0));
                     $(".bank-app-account-balance").data('balance', (data.NewBalance).toFixed(0));
                     QB.Phone.Notifications.Add("fas fa-university", "QBank", "You have transfered &#36; "+amount+"!", "#badc58", 1500);
+                    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
                 } else {
                     QB.Phone.Notifications.Add("fas fa-university", "QBank", "You don't have enough balance!", "#badc58", 1500);
+                    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
                 }
                 QB.Phone.Animations.TopSlideUp(".bank-app-transfer", 400, -100);
             });
     } else {
         QB.Phone.Notifications.Add("fas fa-university", "QBank", "Fill out all fields!", "#badc58", 1750);
+        $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     }
 });
 

--- a/html/js/crypto.js
+++ b/html/js/crypto.js
@@ -109,6 +109,7 @@ $(document).on('click', '.crypto-header-footer-item', function(e){
 
 $(document).on('click', '.cryptotab-general-action', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
 
     var Tab = $(this).data('action');
 
@@ -123,7 +124,7 @@ $(document).on('click', '.cryptotab-general-action', function(e){
 
 $(document).on('click', '#cancel-crypto', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $(".crypto-action-page").animate({
         left: -30+"vh",
     }, 300, function(){
@@ -135,6 +136,7 @@ $(document).on('click', '#cancel-crypto', function(e){
 });
 
 function CloseCryptoPage() {
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $(".crypto-action-page").animate({
         left: -30+"vh",
     }, 300, function(){
@@ -147,7 +149,6 @@ function CloseCryptoPage() {
 
 $(document).on('click', '#buy-crypto', function(e){
     e.preventDefault();
-
     var Coins = $(".crypto-action-page-buy-crypto-input-coins").val();
     var Price = Math.ceil(Coins * CryptoData.Worth);
 
@@ -164,13 +165,16 @@ $(document).on('click', '#buy-crypto', function(e){
                     QB.Phone.Notifications.Add("fas fa-university", "QBank", "&#36; "+Price+",- has been withdrawn from your balance!", "#badc58", 2500);
                 } else {
                     QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "You don't have enough money..", "#badc58", 1500);
+                    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
                 }
             });
         } else {
             QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "You don't have enough money..", "#badc58", 1500);
+            $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
         }
     } else {
         QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "Fill out all fields!", "#badc58", 1500);
+        $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     }
 });
 
@@ -195,15 +199,17 @@ $(document).on('click', '#sell-crypto', function(e){
                     QB.Phone.Notifications.Add("fas fa-university", "QBank", "&#36; "+Price+",- has been added to your balance!", "#badc58", 2500);
                 } else {
                     QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "You don't have enough Qbits..", "#badc58", 1500);
+                    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
                 }
             });
         } else {
             QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "You don't have enough Qbits..", "#badc58", 1500);
+            $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
         }
     } else {
         QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "Fill out all fields!", "#badc58", 1500);
+        $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     }
-    CloseCryptoPage();
     e.handled = false;
 }
 });
@@ -223,8 +229,10 @@ $(document).on('click', '#transfer-crypto', function(e){
                 }), function(CryptoData){
                     if (CryptoData == "notenough") {
                         QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "You don't have enough Qbits..", "#badc58", 1500);
+                        $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
                     } else if (CryptoData == "notvalid") {
                         QB.Phone.Notifications.Add("fas fa-university", "Crypto", "this Wallet-ID doesn't exist!", "#badc58", 2500);
+                        $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
                     } else {
                         UpdateCryptoData(CryptoData)
                         CloseCryptoPage()
@@ -233,12 +241,15 @@ $(document).on('click', '#transfer-crypto', function(e){
                 });
             } else {
                 QB.Phone.Notifications.Add("fas fa-university", "Crypto", "You can't transfer to yourself..", "#badc58", 2500);
+                $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
             }
         } else {
             QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "You don't have enough Qbits..", "#badc58", 1500);
+            $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
         }
     } else {
         QB.Phone.Notifications.Add("fas fa-chart-pie", "Crypto", "Fill out all fields!!", "#badc58", 1500);
+        $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     }
 });
 

--- a/html/js/gallery.js
+++ b/html/js/gallery.js
@@ -1,4 +1,5 @@
 function setUpGalleryData(Images){
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $(".gallery-images").html("");
     if (Images != null) {
         $.each(Images, function(i, image){
@@ -38,6 +39,7 @@ $(document).on('click', '#delete-button', function(e){
         $.post('https://qb-phone/DeleteImage', JSON.stringify({image:source}), function(Hashtags){
             setTimeout(()=>{
                 $('#return-button').click()
+                $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
                 $.post('https://qb-phone/GetGalleryData', JSON.stringify({}), function(data){
                     setTimeout(()=>{
                             setUpGalleryData(data);
@@ -61,6 +63,7 @@ function SetupPostDetails(){
 
 $(document).on('click', '#make-post-button', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     let source = $('#imagedata').attr('src')
     postImageUrl=source
 
@@ -77,7 +80,7 @@ $(document).on('click', '#make-post-button', function(e){
 
 $(document).on('click', '#return-button', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $(".gallery-homescreen").animate({
         left: 00+"vh"
     }, 200);
@@ -88,6 +91,7 @@ $(document).on('click', '#return-button', function(e){
 
 $(document).on('click', '#returndetail-button', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     returnDetail();
     
 });

--- a/html/js/houses.js
+++ b/html/js/houses.js
@@ -55,6 +55,7 @@ var AnimationDuration = 200;
 
 $(document).on('click', '#myhouse-option-transfer', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
 
     $(".myhouses-options").animate({
         left: -35+"vw"
@@ -126,6 +127,7 @@ function shakeElement(element){
 
 $(document).on('click', '#myhouse-option-transfer-confirm', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
         
     var NewBSN = $(".myhouse-option-transfer-container-citizenid").val();
 
@@ -158,6 +160,7 @@ $(document).on('click', '#myhouse-option-transfer-confirm', function(e){
 
 $(document).on('click', '#myhouse-option-transfer-back', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
 
     $(".myhouses-options").animate({
         left: 0

--- a/html/js/mail.js
+++ b/html/js/mail.js
@@ -120,6 +120,7 @@ QB.Phone.Functions.SetupMail = function(MailData) {
 
 $(document).on('click', '.test-slet', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     $(".advert-home").animate({
         left: 30+"vh"
     });
@@ -129,12 +130,14 @@ $(document).on('click', '.test-slet', function(e){
 });
 
 $(document).on('click','.advimage', function (){
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     let source = $(this).attr('src')
     QB.Screen.popUp(source);
 });
 
 $(document).on('click','#new-advert-photo',function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $.post('https://qb-phone/TakePhoto',function(url){
         if(url){
             $('#advert-new-url').val(url)
@@ -145,6 +148,7 @@ $(document).on('click','#new-advert-photo',function(e){
 
 $(document).on('click', '#new-advert-back', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
 
     $(".advert-home").animate({
         left: 0+"vh"
@@ -156,6 +160,7 @@ $(document).on('click', '#new-advert-back', function(e){
 
 $(document).on('click', '#new-advert-submit', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     var Advert = $(".new-advert-textarea").val();
     let picture = $('#advert-new-url').val();
 
@@ -181,6 +186,7 @@ $(document).on('click', '#new-advert-submit', function(e){
         $(".new-advert-textarea").val("");
     } else {
         QB.Phone.Notifications.Add("fas fa-ad", "Advertisement", "You can\'t post an empty ad!", "#ff8f1a", 2000);
+        $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     }
 });
 

--- a/html/js/meos.js
+++ b/html/js/meos.js
@@ -8,6 +8,7 @@ $(document).on('click', '.meos-block', function(e){
 });
 
 OpenMeosPage = function(page) {
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     CurrentMeosPage = page;
     $(".meos-"+CurrentMeosPage+"-page").css({"display":"block"});
     $(".meos-homescreen").animate({
@@ -31,6 +32,7 @@ SetupMeosHome = function() {
 }
 
 MeosHomePage = function() {
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $(".meos-tabs-footer").animate({
         bottom: -5+"vh"
     }, 200);
@@ -198,6 +200,7 @@ $(document).on('click', '.confirm-search-person-test', function(e){
                 });
             } else {
                 QB.Phone.Notifications.Add("politie", "MDT", "There are no search results!");
+                $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
                 $(".person-search-results").html("");
             }
         });

--- a/html/js/phone.js
+++ b/html/js/phone.js
@@ -223,6 +223,7 @@ QB.Phone.Functions.LoadContacts = function(myContacts) {
 };
 
 $(document).on('click', '#new-chat-phone', function(e){
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     var ContactId = $(this).parent().parent().data('contactid');
     var ContactData = $("[data-contactid='"+ContactId+"']").data('contactData');
 
@@ -267,6 +268,7 @@ var CurrentEditContactData = {}
 
 $(document).on('click', '#edit-contact', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     var ContactId = $(this).parent().parent().data('contactid');
     var ContactData = $("[data-contactid='"+ContactId+"']").data('contactData');
 
@@ -293,7 +295,7 @@ $(document).on('click', '#edit-contact', function(e){
 
 $(document).on('click', '#edit-contact-save', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     var ContactName = DOMPurify.sanitize($(".phone-edit-contact-name").val() , {
         ALLOWED_TAGS: [],
         ALLOWED_ATTR: []
@@ -325,7 +327,7 @@ $(document).on('click', '#edit-contact-save', function(e){
 
 $(document).on('click', '#edit-contact-delete', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     var ContactName = $(".phone-edit-contact-name").val();
     var ContactNumber = $(".phone-edit-contact-number").val();
     var ContactIban = $(".phone-edit-contact-iban").val();
@@ -346,7 +348,7 @@ $(document).on('click', '#edit-contact-delete', function(e){
 
 $(document).on('click', '#edit-contact-cancel', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     QB.Phone.Animations.TopSlideUp(".phone-edit-contact", 250, -100);
     setTimeout(function(){
         $(".phone-edit-contact-number").val("");

--- a/html/js/racing.js
+++ b/html/js/racing.js
@@ -65,6 +65,7 @@ function IsCreator(CitizenId, RaceData) {
 
 function SetupRaces(Races) {
     $(".racing-races").html("");
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     if (Races.length > 0) {
         Races = (Races).reverse();
         $.each(Races, function(i, race){

--- a/html/js/settings.js
+++ b/html/js/settings.js
@@ -48,7 +48,7 @@ $(document).on('click', '#accept-background', function(e){
         QB.Phone.Animations.TopSlideUp(".settings-"+QB.Phone.Settings.OpenedTab+"-tab", 200, -100);
         $(".phone-background").css({"background-image":"url('"+QB.Phone.Settings.Background+"')"});
     }
-
+    
     $.post('https://qb-phone/SetBackground', JSON.stringify({
         background: QB.Phone.Settings.Background,
     }))
@@ -78,6 +78,7 @@ QB.Phone.Functions.LoadMetaData = function(MetaData) {
 
 $(document).on('click', '#cancel-background', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     QB.Phone.Animations.TopSlideUp(".settings-"+QB.Phone.Settings.OpenedTab+"-tab", 200, -100);
 });
 
@@ -93,6 +94,7 @@ QB.Phone.Functions.IsBackgroundCustom = function() {
 
 $(document).on('click', '.background-option', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     PressedBackground = $(this).data('background');
     PressedBackgroundObject = this;
     OldBackground = $(this).parent().find('.background-option-current');
@@ -124,7 +126,7 @@ $(document).on('click', '#accept-custom-background', function(e){
 
 $(document).on('click', '#cancel-custom-background', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     QB.Phone.Animations.TopSlideUp(".background-custom", 200, -23);
 });
 
@@ -164,6 +166,7 @@ $(document).on('click', '#accept-custom-profilepicture', function(e){
 
 $(document).on('click', '.profilepicture-option', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     PressedProfilePicture = $(this).data('profilepicture');
     PressedProfilePictureObject = this;
     OldProfilePicture = $(this).parent().find('.profilepicture-option-current');
@@ -183,11 +186,13 @@ $(document).on('click', '.profilepicture-option', function(e){
 
 $(document).on('click', '#cancel-profilepicture', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     QB.Phone.Animations.TopSlideUp(".settings-"+QB.Phone.Settings.OpenedTab+"-tab", 200, -100);
 });
 
 
 $(document).on('click', '#cancel-custom-profilepicture', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     QB.Phone.Animations.TopSlideUp(".profilepicture-custom", 200, -23);
 });

--- a/html/js/twitter.js
+++ b/html/js/twitter.js
@@ -66,7 +66,7 @@ $(document).on('click', '.twitter-header-tab', function(e){
 
 $(document).on('click', '.twitter-new-tweet', function(e){
     e.preventDefault();
-
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
     QB.Phone.Animations.TopSlideDown(".twitter-new-tweet-tab", 450, 0);
 });
 
@@ -134,6 +134,7 @@ $(document).on('click', '.tweet-reply', function(e){
     var TwtName = $(this).parent().data('twthandler');
     $('#tweet-new-url').val("");
     $("#tweet-new-message").val(TwtName + " ");
+
     QB.Phone.Animations.TopSlideDown(".twitter-new-tweet-tab", 450, 0);
 });
 
@@ -236,6 +237,7 @@ $(document).on('click', '#send-tweet', function(e){
 
 $(document).on('click', '#cancel-tweet', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
     $('#tweet-new-url').html("");
     QB.Phone.Animations.TopSlideUp(".twitter-new-tweet-tab", 450, -120);
 });

--- a/html/js/whatsapp.js
+++ b/html/js/whatsapp.js
@@ -184,6 +184,7 @@ FormatMessageTime = function() {
 
 $(document).on('click', '#whatsapp-openedchat-send', function(e){
     e.preventDefault();
+    $.post('https://qb-phone/SetFocusInput', JSON.stringify({}), function(){})
 
     var Message = $("#whatsapp-openedchat-message").val();
 
@@ -195,6 +196,7 @@ $(document).on('click', '#whatsapp-openedchat-send', function(e){
             ChatTime: FormatMessageTime(),
             ChatType: "message",
         }));
+        $.post('https://qb-phone/ReleaseFocusInput', JSON.stringify({}), function(){})
         $("#whatsapp-openedchat-message").val("");
         $("div.emojionearea-editor").data("emojioneArea").setText('');
     } else {


### PR DESCRIPTION
Allows for movement while using phone, but dynamically locks to Phone UI when typed input is required from user.

Detail:
-Utilizes SetNuiFocusKeepInput() in appropriate to places to trigger UI focus on/off
-Tested within each app to make sure it changes state of Focused/Not Focused  appropriately.
-Cleaned up some inappropriate behaviors in apps with inconsistent behavior. 
i.e. within some apps, if you fail to input information and get an error, it closes the app. Others it doesn't. Now they uniformly leave the app open and allows user to re-input information without having to re-open app.

Closes #343, #320 