### PR TITLE
Update main.lua

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -725,16 +725,30 @@ RegisterNUICallback('UpdateProfilePicture', function(data, cb)
 end)
 
 RegisterNUICallback('PostNewTweet', function(data, cb)
-    local TweetMessage = {
-        firstName = PhoneData.PlayerData.charinfo.firstname,
-        lastName = PhoneData.PlayerData.charinfo.lastname,
-        citizenid = PhoneData.PlayerData.citizenid,
-        message = escape_str(data.Message),
-        time = data.Date,
-        tweetId = GenerateTweetId(),
-        picture = data.Picture,
-        url = data.url
-    }
+    local TweetMessage = {}--Prevent send null value to database if Linux mode is on
+    if Config.Linux then
+        TweetMessage = {
+            firstName = PhoneData.PlayerData.charinfo.firstname,
+            lastName = PhoneData.PlayerData.charinfo.lastname,
+            citizenid = PhoneData.PlayerData.citizenid,
+            message = escape_str(data.Message),
+            date = data.Date,
+            tweetId = GenerateTweetId(),
+            picture = data.Picture,
+            url = data.url
+        }
+    else
+        TweetMessage = {
+            firstName = PhoneData.PlayerData.charinfo.firstname,
+            lastName = PhoneData.PlayerData.charinfo.lastname,
+            citizenid = PhoneData.PlayerData.citizenid,
+            message = escape_str(data.Message),
+            time = data.Date,
+            tweetId = GenerateTweetId(),
+            picture = data.Picture,
+            url = data.url
+        }
+    end
 
     local TwitterMessage = data.Message
     local MentionTag = TwitterMessage:split("@")


### PR DESCRIPTION
Prevent send null value to database if Linux mode is on

## Description

fix client send a null value datetime to server when 'Linux config' is on to make SnC run smooth
<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
