### PR TITLE
PMA or SaltyChat Usage is now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ ensure qb-banking
 
 Config = Config or {}
 
+Config.useSaltyChat =  false -- True if you use SaltyChat
 Config.RepeatTimeout = 2000 -- Timeout for unanswered call notification
 Config.CallRepeats = 10 -- Repeats for unanswered call notification
 Config.OpenPhone = 244 -- Key to open phone display

--- a/client/main.lua
+++ b/client/main.lua
@@ -316,7 +316,13 @@ end
 local function CancelCall()
     TriggerServerEvent('qb-phone:server:CancelCall', PhoneData.CallData)
     if PhoneData.CallData.CallType == "ongoing" then
-        exports['pma-voice']:removePlayerFromCall(PhoneData.CallData.CallId)
+        
+        if Config.useSaltyChat == true
+            exports['saltychat']:EndCall(Play.PlayerData.source, Ply.PlayerData.source) 
+        else
+            exports['pma-voice']:removePlayerFromCall(PhoneData.CallData.CallId)
+        end
+        
     end
     PhoneData.CallData.CallType = nil
     PhoneData.CallData.InCall = false
@@ -1659,7 +1665,11 @@ RegisterNetEvent('qb-phone:client:CancelCall', function()
         SendNUIMessage({
             action = "CancelOngoingCall"
         })
-        exports['pma-voice']:removePlayerFromCall(PhoneData.CallData.CallId)
+        if Config.Tokovoip and Config.useSaltyChat == true then
+            exports['saltychat']:EndCall(Play.PlayerData.source, Ply.PlayerData.source)
+        else
+            exports['pma-voice']:removePlayerFromCall(PhoneData.CallData.CallId)
+        end        
     end
     PhoneData.CallData.CallType = nil
     PhoneData.CallData.InCall = false
@@ -2040,7 +2050,14 @@ RegisterNetEvent('qb-phone:client:AnswerCall', function()
                 Wait(1000)
             end
         end)
-        exports['pma-voice']:addPlayerToCall(PhoneData.CallData.CallId)
+
+        if Config.Tokovoip and Config.useSaltyChat == true then
+            exports['saltychat']:EstablishCall(Play.PlayerData.source, Ply.PlayerData.source)
+            exports['saltychat']:EstablishCall(Ply.PlayerData.source, Play.PlayerData.source)
+        else
+            exports['pma-voice']:addPlayerToCall(PhoneData.CallData.CallId)
+        end
+        
     else
         PhoneData.CallData.InCall = false
         PhoneData.CallData.CallType = nil

--- a/client/main.lua
+++ b/client/main.lua
@@ -317,8 +317,8 @@ local function CancelCall()
     TriggerServerEvent('qb-phone:server:CancelCall', PhoneData.CallData)
     if PhoneData.CallData.CallType == "ongoing" then
         
-        if Config.useSaltyChat == true
-            exports['saltychat']:EndCall(Play.PlayerData.source, Ply.PlayerData.source) 
+        if Config.Tokovoip and Config.useSaltyChat == true then
+            exports['saltychat']:EndCall(Play.PlayerData.source, Ply.PlayerData.source)
         else
             exports['pma-voice']:removePlayerFromCall(PhoneData.CallData.CallId)
         end

--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,7 @@ Config.BillingCommissions = { -- This is a percentage (0.10) == 10%
     mechanic = 0.10
 }
 Config.Linux = false -- True if linux
+Config.useSaltyChat =  false -- True if you use SaltyChat
 Config.TweetDuration = 12 -- How many hours to load tweets (12 will load the past 12 hours of tweets)
 Config.RepeatTimeout = 2000
 Config.CallRepeats = 10

--- a/config.lua
+++ b/config.lua
@@ -3,7 +3,7 @@ Config.BillingCommissions = { -- This is a percentage (0.10) == 10%
     mechanic = 0.10
 }
 Config.Linux = false -- True if linux
-Config.useSaltyChat =  false -- True if you use SaltyChat
+Config.useSaltyChat = true -- True if you use SaltyChat
 Config.TweetDuration = 12 -- How many hours to load tweets (12 will load the past 12 hours of tweets)
 Config.RepeatTimeout = 2000
 Config.CallRepeats = 10

--- a/server/main.lua
+++ b/server/main.lua
@@ -944,16 +944,30 @@ RegisterNetEvent('qb-phone:server:AddRecentCall', function(type, data)
 end)
 
 RegisterNetEvent('qb-phone:server:CancelCall', function(ContactData)
+    local src = source
+    local Play = QBCore.Functions.GetPlayer(src)
     local Ply = QBCore.Functions.GetPlayerByPhone(ContactData.TargetData.number)
     if Ply ~= nil then
         TriggerClientEvent('qb-phone:client:CancelCall', Ply.PlayerData.source)
+
+        if Config.useSaltyChat == true then
+            exports['saltychat']:EndCall(Play.PlayerData.source, Ply.PlayerData.source)
+            exports['saltychat']:EndCall(Ply.PlayerData.source, Play.PlayerData.source)
+        end
     end
 end)
 
 RegisterNetEvent('qb-phone:server:AnswerCall', function(CallData)
+    local src = source
+    local Play = QBCore.Functions.GetPlayer(src)
     local Ply = QBCore.Functions.GetPlayerByPhone(CallData.TargetData.number)
     if Ply ~= nil then
         TriggerClientEvent('qb-phone:client:AnswerCall', Ply.PlayerData.source)
+
+        if Config.useSaltyChat == true then
+            exports['saltychat']:EstablishCall(Play.PlayerData.source, Ply.PlayerData.source)
+            exports['saltychat']:EstablishCall(Ply.PlayerData.source, Play.PlayerData.source)
+        end
     end
 end)
 


### PR DESCRIPTION
## Description

This changes able to user to configure qb-phone to use PMA or SaltyChat voice

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
