### PR TITLE
fix(garages-cb): Vehicle app missing data

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -299,7 +299,7 @@ local function OpenPhone()
                 newPhoneProp()
             end)
 
-            QBCore.Functions.TriggerCallback('qb-garage:server:GetPlayerVehicles', function(vehicles)
+            QBCore.Functions.TriggerCallback('qb-garages:server:GetPlayerVehicles', function(vehicles)
                 PhoneData.GarageVehicles = vehicles
             end)
         else


### PR DESCRIPTION
## Description

Incorrectly named callback, caused vehicle app to display no vehicles

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
