### PR TITLE
Fix Fivemerr bug and Tweets on Linux hosts bug

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1389,7 +1389,7 @@ RegisterNUICallback('TakePhoto', function(_, cb)
             cb(json.encode({ url = nil }))
             break
         elseif IsControlJustPressed(1, 176) then -- TAKE.. PIC
-            if Config.Fivemerr == true and Config.FivemerrApiToken ~= '' then
+            if Config.Fivemerr == true then
                 -- Fivemerr uploads via the server using screenshot-basic to further guard your API key.
                 return QBCore.Functions.TriggerCallback('qb-phone:server:UploadToFivemerr', function(fivemerrData)
                     if fivemerrData == nil then

--- a/client/main.lua
+++ b/client/main.lua
@@ -1389,7 +1389,7 @@ RegisterNUICallback('TakePhoto', function(_, cb)
             cb(json.encode({ url = nil }))
             break
         elseif IsControlJustPressed(1, 176) then -- TAKE.. PIC
-            if Config.Fivemerr == true then
+            if Config.Fivemerr == true and Config.FivemerrApiToken ~= '' then
                 -- Fivemerr uploads via the server using screenshot-basic to further guard your API key.
                 return QBCore.Functions.TriggerCallback('qb-phone:server:UploadToFivemerr', function(fivemerrData)
                     if fivemerrData == nil then

--- a/config.lua
+++ b/config.lua
@@ -7,12 +7,10 @@ Config.TweetDuration = 12 -- How many hours to load tweets (12 will load the pas
 Config.RepeatTimeout = 2000
 Config.CallRepeats = 10
 Config.OpenPhone = 'M'
-Config.WebHook = ''
 
 -- Set this to true if you wish to use Fivemerr (https://fivemerr.com/) for media uploads. 
 -- Ensure to add your API key to server/main.lua 
 Config.Fivemerr = false
-Config.FivemerrApiToken = ''
 
 Config.PhoneApplications = {
     ['phone'] = {

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,6 @@ Config = Config or {}
 Config.BillingCommissions = { -- This is a percentage (0.10) == 10%
     mechanic = 0.10
 }
-Config.Linux = false      -- True if linux
 Config.TweetDuration = 12 -- How many hours to load tweets (12 will load the past 12 hours of tweets)
 Config.RepeatTimeout = 2000
 Config.CallRepeats = 10

--- a/config.lua
+++ b/config.lua
@@ -7,10 +7,12 @@ Config.TweetDuration = 12 -- How many hours to load tweets (12 will load the pas
 Config.RepeatTimeout = 2000
 Config.CallRepeats = 10
 Config.OpenPhone = 'M'
+Config.WebHook = ''
 
 -- Set this to true if you wish to use Fivemerr (https://fivemerr.com/) for media uploads. 
 -- Ensure to add your API key to server/main.lua 
 Config.Fivemerr = false
+Config.FivemerrApiToken = ''
 
 Config.PhoneApplications = {
     ['phone'] = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -613,7 +613,7 @@ end)
 QBCore.Functions.CreateCallback('qb-phone:server:UploadToFivemerr', function(source, cb)
     local src = source
 
-    if Config.Fivemerr == true and Config.FivemerrApiToken == '' then
+    if Config.Fivemerr == true and FivemerrApiToken == '' then
         print("^1--- Fivemerr is enabled but no API token has been specified. ---^7")
         return cb(nil)
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -833,31 +833,18 @@ end)
 
 RegisterNetEvent('qb-phone:server:UpdateTweets', function(NewTweets, TweetData)
     local src = source
-    if Config.Linux then
-        MySQL.insert('INSERT INTO phone_tweets (citizenid, firstName, lastName, message, date, url, picture, tweetid) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', {
-            TweetData.citizenid,
-            TweetData.firstName,
-            TweetData.lastName,
-            TweetData.message,
-            TweetData.date,
-            TweetData.url:gsub('[%<>\"()\' $]', ''),
-            TweetData.picture:gsub('[%<>\"()\' $]', ''),
-            TweetData.tweetId
-        })
-        TriggerClientEvent('qb-phone:client:UpdateTweets', -1, src, NewTweets, TweetData, false)
-    else
-        MySQL.insert('INSERT INTO phone_tweets (citizenid, firstName, lastName, message, date, url, picture, tweetid) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', {
-            TweetData.citizenid,
-            TweetData.firstName,
-            TweetData.lastName,
-            TweetData.message,
-            TweetData.time,
-            TweetData.url:gsub('[%<>\"()\' $]', ''),
-            TweetData.picture:gsub('[%<>\"()\' $]', ''),
-            TweetData.tweetId
-        })
-        TriggerClientEvent('qb-phone:client:UpdateTweets', -1, src, NewTweets, TweetData, false)
-    end
+
+    MySQL.insert('INSERT INTO phone_tweets (citizenid, firstName, lastName, message, date, url, picture, tweetid) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', {
+        TweetData.citizenid,
+        TweetData.firstName,
+        TweetData.lastName,
+        TweetData.message,
+        TweetData.time,
+        TweetData.url:gsub('[%<>\"()\' $]', ''),
+        TweetData.picture:gsub('[%<>\"()\' $]', ''),
+        TweetData.tweetId
+    })
+    TriggerClientEvent('qb-phone:client:UpdateTweets', -1, src, NewTweets, TweetData, false)
 end)
 
 RegisterNetEvent('qb-phone:server:TransferMoney', function(iban, amount)

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,8 +6,8 @@ local Hashtags = {}
 local Calls = {}
 local Adverts = {}
 local GeneratedPlates = {}
-local WebHook = ''
-local FivemerrApiToken = 'API_KEY_HERE'
+local WebHook = Config.WebHook
+local FivemerrApiToken = Config.FivemerrApiToken
 local bannedCharacters = { '%', '$', ';' }
 local TWData = {}
 
@@ -613,7 +613,7 @@ end)
 QBCore.Functions.CreateCallback('qb-phone:server:UploadToFivemerr', function(source, cb)
     local src = source
 
-    if Config.Fivemerr == '' then
+    if Config.Fivemerr == true and Config.FivemerrApiToken == '' then
         print("^1--- Fivemerr is enabled but no API token has been specified. ---^7")
         return cb(nil)
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,8 +6,8 @@ local Hashtags = {}
 local Calls = {}
 local Adverts = {}
 local GeneratedPlates = {}
-local WebHook = Config.WebHook
-local FivemerrApiToken = Config.FivemerrApiToken
+local WebHook = ''
+local FivemerrApiToken = ''
 local bannedCharacters = { '%', '$', ';' }
 local TWData = {}
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -34,14 +34,6 @@ local function escape_sqli(source)
     return source:gsub("['\"]", replacements)
 end
 
-local function round(num, numDecimalPlaces)
-    if numDecimalPlaces and numDecimalPlaces > 0 then
-        local mult = 10 ^ numDecimalPlaces
-        return math.floor(num * mult + 0.5) / mult
-    end
-    return math.floor(num + 0.5)
-end
-
 function QBPhone.AddMentionedTweet(citizenid, TweetData)
     if MentionedTweets[citizenid] == nil then
         MentionedTweets[citizenid] = {}
@@ -298,7 +290,7 @@ QBCore.Functions.CreateCallback('qb-phone:server:PayInvoice', function(source, c
 
         if exists[1] and exists[1]["count"] == 1 then
             if SenderPly and Config.BillingCommissions[society] then
-                local commission = round(amount * Config.BillingCommissions[society])
+                local commission = QBCore.Shared.Round(amount * Config.BillingCommissions[society])
                 SenderPly.Functions.AddMoney('bank', commission)
                 invoiceMailData = {
                     sender = 'Billing Department',
@@ -888,7 +880,7 @@ RegisterNetEvent('qb-phone:server:TransferMoney', function(iban, amount)
             end
         else
             local moneyInfo = json.decode(result[1].money)
-            moneyInfo.bank = round((moneyInfo.bank + amount))
+            moneyInfo.bank = QBCore.Shared.Round(moneyInfo.bank + amount)
             MySQL.update('UPDATE players SET money = ? WHERE citizenid = ?',
                 { json.encode(moneyInfo), result[1].citizenid })
             sender.Functions.RemoveMoney('bank', amount, 'phone-transfered')


### PR DESCRIPTION
## Description

1. Fixed FiveMerr bug related to API Token checking.
2. Use the native QBCore Round function
3. Fixed Linux bug with Tweets date/time when Config.Linux was set to true

I think the config.lua should be the only place config parameters are being set. I moved the WebHook and FivemerrApiToken definitions to config.lua and also improved a few of the if conditions.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
